### PR TITLE
A bonus card scanned without any items should still have a total of zero

### DIFF
--- a/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
+++ b/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
@@ -6,5 +6,9 @@
         {
             return 0;
         }
+
+        public void Scan(int SKU)
+        {
+        }
     }
 }

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -4,10 +4,23 @@ namespace Tests.Unit.Excella.CheckoutMachine
 {
     public class SelfCheckoutMachineTests
     {
+
         [Test]
         public void GetTotal_WithNoItemsScanned_Returns0()
         {
             var sut = new SelfCheckoutMachine();
+
+            var result = sut.GetTotal();
+
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void GetTotal_WhenOnlyBonusCardScanned_Returns0()
+        {
+            var sut = new SelfCheckoutMachine();
+
+            sut.Scan(999); // I've chosen 999 as the bonus card SKU
 
             var result = sut.GetTotal();
 


### PR DESCRIPTION
Resolves #4.