### PR TITLE
Test refactor: TestCase for single item tests

### DIFF
--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -27,6 +27,17 @@ namespace Tests.Unit.Excella.CheckoutMachine
             Assert.That(result, Is.EqualTo(0));
         }
 
+        [TestCase(Constants.SkuNumbers.CHIPS, 200)]
+        public void Scan_WithSingleItem_ExpectTotalToBePriceOfThatItem(int singleItemSku, int expectedTotal)
+        {
+            var sut = new SelfCheckoutMachine();
+
+            sut.Scan(singleItemSku);
+            var result = sut.GetTotal();
+
+            Assert.That(result, Is.EqualTo(expectedTotal));
+        }
+
         [Test]
         public void Scan_WithChips_ExpectTotalOf200()
         {

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -42,55 +42,6 @@ namespace Tests.Unit.Excella.CheckoutMachine
         }
 
         [Test]
-        public void Scan_WithChips_ExpectTotalOf200()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.CHIPS); 
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(200));
-        }
-
-        [Test]
-        public void Scan_WithSalsa_ExpectTotalOf100()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.SALSA);
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(100));
-        }
-
-        [Test]
-        public void Scan_WithWine_ExpectTotalOf1000()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.WINE);
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(1000));
-        }
-
-        [Test]
-        public void Scan_WithCigarettes_ExpectTotalOf500()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.CIGARETTES);
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(500));
-        }
-
-
-        [Test]
         public void Scan_WithTwoBagsOfChips_ExpectTotalOf400()
         {
             var sut = new SelfCheckoutMachine();

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -28,6 +28,9 @@ namespace Tests.Unit.Excella.CheckoutMachine
         }
 
         [TestCase(Constants.SkuNumbers.CHIPS, 200)]
+        [TestCase(Constants.SkuNumbers.SALSA, 100)]
+        [TestCase(Constants.SkuNumbers.WINE, 1000)]
+        [TestCase(Constants.SkuNumbers.CIGARETTES, 500)]
         public void Scan_WithSingleItem_ExpectTotalToBePriceOfThatItem(int singleItemSku, int expectedTotal)
         {
             var sut = new SelfCheckoutMachine();


### PR DESCRIPTION
We have several tests that are testing the same kind of generic concept -- when I scan a single item, the total should be that item's price.

This means we can use a test case.

This PR introduces a test case and removes the other individual tests, only after making sure we have the same level of test coverage.