### PR TITLE
Test Refactor: Test case for the double item test

### DIFF
--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -58,55 +58,6 @@ namespace Tests.Unit.Excella.CheckoutMachine
         }
 
         [Test]
-        public void Scan_WithTwoBagsOfChips_ExpectTotalOf400()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.CHIPS);
-            sut.Scan(Constants.SkuNumbers.CHIPS);
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(400));
-        }
-
-        [Test]
-        public void Scan_WithTwoSalsas_ExpectTotalOf200()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.SALSA);
-            sut.Scan(Constants.SkuNumbers.SALSA);
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(200));
-        }
-        [Test]
-        public void Scan_WithTwoWines_ExpectTotalOf2000()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.WINE);
-            sut.Scan(Constants.SkuNumbers.WINE);
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(2000));
-        }
-        [Test]
-        public void Scan_WithTwoCigarettes_ExpectTotalOf1000()
-        {
-            var sut = new SelfCheckoutMachine();
-
-            sut.Scan(Constants.SkuNumbers.CIGARETTES);
-            sut.Scan(Constants.SkuNumbers.CIGARETTES);
-
-            var result = sut.GetTotal();
-
-            Assert.That(result, Is.EqualTo(1000));
-        }
-        [Test]
         public void Scan_WithOneOfEachItem_ExpectTotalOf1800()
         {
             var sut = new SelfCheckoutMachine();

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -41,6 +41,22 @@ namespace Tests.Unit.Excella.CheckoutMachine
             Assert.That(result, Is.EqualTo(expectedTotal));
         }
 
+        [TestCase(Constants.SkuNumbers.CHIPS, 400)]
+        [TestCase(Constants.SkuNumbers.SALSA, 200)]
+        [TestCase(Constants.SkuNumbers.WINE, 2000)]
+        [TestCase(Constants.SkuNumbers.CIGARETTES, 1000)]
+        public void Scan_WithTwoOfAnItem_ExpectTotalToBeTwiceTheItemPrice(int sku, int expectedTotal)
+        {
+            var sut = new SelfCheckoutMachine();
+
+            sut.Scan(sku);
+            sut.Scan(sku);
+
+            var result = sut.GetTotal();
+
+            Assert.That(result, Is.EqualTo(expectedTotal));
+        }
+
         [Test]
         public void Scan_WithTwoBagsOfChips_ExpectTotalOf400()
         {


### PR DESCRIPTION
Similar to #27, we can refactor the dual scan scenario into a test case to consolidate our tests.

I did this only after ensuring that all tests passed along each step before deleting any tests.