### PR TITLE
Bonus Card: Salsa

### DIFF
--- a/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
+++ b/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
@@ -3,7 +3,7 @@
     public class SelfCheckoutMachine
     {
         private int _total;
-
+        private bool _bonusCardScanned = false;
         public int GetTotal()
         {
             return _total;
@@ -11,6 +11,10 @@
 
         public void Scan(int SKU)
         {
+            if (SKU == Constants.SkuNumbers.BONUS_CARD)
+            {
+                _bonusCardScanned = true;
+            }
             if (SKU == Constants.SkuNumbers.CHIPS)
             {
                 _total += 200;

--- a/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
+++ b/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
@@ -3,10 +3,17 @@
     public class SelfCheckoutMachine
     {
         private int _total;
+
         private bool _bonusCardScanned = false;
+        private int salsaCount = 0;
         public int GetTotal()
         {
-            return _total;
+            int discount = 0;
+            if (_bonusCardScanned)
+            {
+                discount = discount + (salsaCount*50);
+            }
+            return _total - discount;
         }
 
         public void Scan(int SKU)
@@ -21,6 +28,7 @@
             }
             if (SKU == Constants.SkuNumbers.SALSA)
             {
+                salsaCount++;
                 _total += 100;
             }
             if (SKU == Constants.SkuNumbers.WINE)

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -71,5 +71,18 @@ namespace Tests.Unit.Excella.CheckoutMachine
 
             Assert.That(result, Is.EqualTo(1800));
         }
+
+        [Test]
+        public void Scan_WithBonusCard_WhenScanningSalsa_ExpectTotalOf50()
+        {
+            var sut = new SelfCheckoutMachine();
+
+            sut.Scan(Constants.SkuNumbers.BONUS_CARD);
+            sut.Scan(Constants.SkuNumbers.SALSA);
+
+            var result = sut.GetTotal();
+
+            Assert.That(result, Is.EqualTo(50));
+        }
     }
 }


### PR DESCRIPTION
Resolves #30.

When a bonus card is scanned and then salsa is scanned, the salsa is half off.