### PR TITLE
50 cent surcharge on tobacco products

### DIFF
--- a/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
+++ b/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
@@ -13,6 +13,7 @@ namespace Excella.CheckoutMachine
         public int GetTotal()
         {
             int discount = 0;
+            _total = _total + (50 * tobaccoCount);
             if (_bonusCardScanned)
             {
                 discount = discount + (salsaCount*50);

--- a/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
+++ b/src/app/Excella.CheckoutMachine/SelfCheckoutMachine.cs
@@ -9,6 +9,7 @@ namespace Excella.CheckoutMachine
         private bool _bonusCardScanned = false;
         private int salsaCount = 0;
         private int chipCount = 0;
+        private int tobaccoCount = 0;
         public int GetTotal()
         {
             int discount = 0;
@@ -45,6 +46,7 @@ namespace Excella.CheckoutMachine
             }
             if (SKU == Constants.SkuNumbers.CIGARETTES)
             {
+                tobaccoCount++;
                 _total += 500;
             }
         }

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -30,7 +30,7 @@ namespace Tests.Unit.Excella.CheckoutMachine
         [TestCase(Constants.SkuNumbers.CHIPS, 200)]
         [TestCase(Constants.SkuNumbers.SALSA, 100)]
         [TestCase(Constants.SkuNumbers.WINE, 1000)]
-        [TestCase(Constants.SkuNumbers.CIGARETTES, 500)]
+        [TestCase(Constants.SkuNumbers.CIGARETTES, 550)]
         public void Scan_WithSingleItem_ExpectTotalToBePriceOfThatItem(int singleItemSku, int expectedTotal)
         {
             var sut = new SelfCheckoutMachine();

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -44,7 +44,7 @@ namespace Tests.Unit.Excella.CheckoutMachine
         [TestCase(Constants.SkuNumbers.CHIPS, 400)]
         [TestCase(Constants.SkuNumbers.SALSA, 200)]
         [TestCase(Constants.SkuNumbers.WINE, 2000)]
-        [TestCase(Constants.SkuNumbers.CIGARETTES, 1000)]
+        [TestCase(Constants.SkuNumbers.CIGARETTES, 1100)]
         public void Scan_WithTwoOfAnItem_ExpectTotalToBeTwiceTheItemPrice(int sku, int expectedTotal)
         {
             var sut = new SelfCheckoutMachine();

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -58,7 +58,7 @@ namespace Tests.Unit.Excella.CheckoutMachine
         }
 
         [Test]
-        public void Scan_WithOneOfEachItem_ExpectTotalOf1800()
+        public void Scan_WithOneOfEachItem_ExpectTotalOf1850()
         {
             var sut = new SelfCheckoutMachine();
 
@@ -69,7 +69,7 @@ namespace Tests.Unit.Excella.CheckoutMachine
 
             var result = sut.GetTotal();
 
-            Assert.That(result, Is.EqualTo(1800));
+            Assert.That(result, Is.EqualTo(1850));
         }
 
         [Test]

--- a/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
+++ b/src/test/Tests.Unit.Excella.CheckoutMachine/SelfCheckoutMachineTests.cs
@@ -191,5 +191,17 @@ namespace Tests.Unit.Excella.CheckoutMachine
 
             Assert.That(result, Is.EqualTo(1150));
         }
+
+        [Test]
+        public void Scan_Cigarettes_WithTobaccoSurcharge_ExpectTotalToBe550()
+        {
+            var sut = new SelfCheckoutMachine();
+
+            sut.Scan(Constants.SkuNumbers.CIGARETTES);
+
+            var total = sut.GetTotal();
+
+            Assert.That(total, Is.EqualTo(550));
+        }
     }
 }


### PR DESCRIPTION
Resolves #45.

NOTE: As part of this PR, we had to update several tests, because their expectations involved that cigarettes would cost 500 each instead of 550, which is now an invalid expectation.